### PR TITLE
Remove "code" folder from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ install_scripts:
 	cp common/* /tmp/scripts_tmp
 	cp security/password/* /tmp/scripts_tmp
 	cp security/secret-config/* /tmp/scripts_tmp
-	cp code/* /tmp/scripts_tmp
 	rm /tmp/scripts_tmp/*.md
 	chmod +x /tmp/scripts_tmp/*
 	cp /tmp/scripts_tmp/* /usr/bin/


### PR DESCRIPTION
removed line causes following error while installing:
cp: cannot stat 'code/*': No such file or directory
